### PR TITLE
Removed Secret Key for the time being.

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -19,9 +19,6 @@ BASE_DIR = Path(__file__).resolve(strict=True).parent.parent
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '!l4!*$#-f3jmhz4&5c4et01iqs@=4&wsyh1xm0^wck14leuke^'
-
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 


### PR DESCRIPTION
Quick fix on removing the `SECRET_KEY` in `src/settings.py` which is supposed to be for hashing passwords and other stuff, but considering, for now, we don't need to make accounts, there are no negative effects. When we do have to make accounts for admin though, we have to create an environment variable for the production version and keep that private from prying use.