### PR TITLE
Create github actions for linting and testing frontend code

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,0 +1,22 @@
+name: Lint-And-Test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+        working-directory: frontend
+      - run: npm run ci:lint-and-test
+        working-directory: frontend

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,4 +1,4 @@
-name: Lint-And-Test
+name: Lint And Test
 
 on: [push, pull_request]
 
@@ -6,17 +6,30 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    defaults:
+      run:
+        working-directory: frontend
+
     strategy:
       matrix:
         node-version: [12.x, 14.x]
 
     steps:
       - uses: actions/checkout@v2
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm ci
-        working-directory: frontend
-      - run: npm run ci:lint-and-test
-        working-directory: frontend
+      - run: npm -s ci
+      - run: npm -s run ci:lint-and-test

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,10 +26,11 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "eslint": "eslint .",
+    "eslint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "check-types": "tsc --noemit",
-    "lint": "set -x; npm run eslint .; npm run check-types",
-    "fix": "set -x; prettier --write .; eslint --fix .",
+    "lint": "node scripts/npm.js lint",
+    "ci:lint-and-test": "CI=true node scripts/npm.js lint-and-test",
+    "fix": "node scripts/npm.js fix",
     "storybook": "start-storybook -p 6006 -s public",
     "build-storybook": "build-storybook -s public"
   },
@@ -62,7 +63,8 @@
     "husky": "^4.3.0",
     "lint-staged": "^10.4.0",
     "prettier": "2.1.2",
-    "react-is": "^16.13.1"
+    "react-is": "^16.13.1",
+    "shelljs": "^0.8.4"
   },
   "husky": {
     "hooks": {

--- a/frontend/scripts/npm.js
+++ b/frontend/scripts/npm.js
@@ -1,0 +1,14 @@
+const { runCommandsOrFail } = require('./utils');
+
+const npmRun = cmd => `npm -s run ${cmd}`,
+  lint = [npmRun('eslint'), npmRun('check-types')];
+
+const scripts = {
+  fix: ['prettier --write .', 'eslint --fix .'],
+  lint,
+  'lint-and-test': [...lint, npmRun('test')],
+};
+
+const selectedScript = process.argv[2];
+
+runCommandsOrFail(scripts[selectedScript]);

--- a/frontend/scripts/utils.js
+++ b/frontend/scripts/utils.js
@@ -1,0 +1,18 @@
+const process = require('process');
+const shell = require('shelljs');
+
+const runCommands = commands =>
+  commands.map(command => {
+    console.log(`>>> Running "${command}"`);
+    return shell.exec(command).code;
+  });
+
+const runCommandsOrFail = commands => {
+  if (runCommands(commands).some(code => code !== 0)) {
+    failProcess();
+  }
+};
+
+const failProcess = () => (process.exitCode = 1);
+
+module.exports = { runCommandsOrFail };


### PR DESCRIPTION
Closes #132

test runs on my fork [here](https://github.com/alexjball/jobhopper/actions?query=workflow%3A%22Lint+And+Test%22), for both PR's and branches.

Basic setup is copied from [here](https://docs.github.com/en/free-pro-team@latest/actions/guides/building-and-testing-nodejs#starting-with-the-nodejs-workflow-template)

Caching is copied from [here](https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows#example-using-the-cache-action) 

I think all we need to do to start running this on the main repo is merge it and make sure actions are enabled.