### PR TITLE
Feature/transitions duck

### DIFF
--- a/frontend/src/ducks/__tests__/store.ts
+++ b/frontend/src/ducks/__tests__/store.ts
@@ -1,9 +1,12 @@
 import { fetchStates } from '../states';
+import { fetchTransitions } from '../transitions';
 import { fetchOccupations } from '../occupations';
 import { createStore } from '../store';
 import api from '../../services/api';
+import { GetTransitionRequest } from '../../services/api/Api';
 import states from '../../testing/data/states';
 import occupations from '../../testing/data/occupations';
+import transitions from '../../testing/data/transitionData';
 import { mocked } from 'ts-jest/utils';
 
 jest.mock('../../services/api');
@@ -59,5 +62,32 @@ describe('Occupations', () => {
 
     await store.dispatch(fetchOccupations());
     expect(store.getState().occupations.error).toEqual(errorMessage);
+  });
+});
+
+describe('Transitions', () => {
+  it('updates the list of transitions', async () => {
+    const store = createStore();
+    expect(store.getState().transitions.transitions).toHaveLength(0);
+
+    mockedApi.getTransitions.mockResolvedValue(transitions);
+
+    const payload: GetTransitionRequest = { occupation: { code: '1' } };
+
+    await store.dispatch(fetchTransitions(payload));
+    expect(store.getState().transitions.transitions).toEqual(transitions);
+  });
+
+  it('handles update error', async () => {
+    const store = createStore();
+    expect(store.getState().transitions.transitions).toHaveLength(0);
+
+    const errorMessage = 'test error fetching';
+    mockedApi.getTransitions.mockRejectedValue(new Error(errorMessage));
+
+    const payload: GetTransitionRequest = { occupation: { code: '1' } };
+
+    await store.dispatch(fetchTransitions(payload));
+    expect(store.getState().transitions.error).toEqual(errorMessage);
   });
 });

--- a/frontend/src/ducks/store.ts
+++ b/frontend/src/ducks/store.ts
@@ -1,11 +1,13 @@
 import { configureStore } from '@reduxjs/toolkit';
 import states from './states';
 import occupations from './occupations';
+import transitions from './transitions';
 
 export const createStore = () =>
   configureStore({
     reducer: {
       states,
       occupations,
+      transitions,
     },
   });

--- a/frontend/src/ducks/transitions.ts
+++ b/frontend/src/ducks/transitions.ts
@@ -1,0 +1,33 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import { Transition } from '../domain/transition';
+import api from '../services/api';
+import { GetTransitionRequest } from '../services/api/Api';
+
+export const fetchTransitions = createAsyncThunk(
+  'transitions/fetchTransitions',
+  (payload: GetTransitionRequest) => api.getTransitions(payload)
+);
+
+type SliceState = { transitions: Transition[]; error: string | null };
+
+const slice = createSlice({
+  name: 'transitions',
+  initialState: { transitions: [], error: null } as SliceState,
+  reducers: {},
+  extraReducers: builder => {
+    builder.addCase(
+      fetchTransitions.fulfilled,
+      (state, { payload: transitions }) => {
+        state.transitions = transitions;
+      }
+    );
+    builder.addCase(
+      fetchTransitions.rejected,
+      (state, { error: { message = 'Error fetching transitions' } }) => {
+        state.error = message;
+      }
+    );
+  },
+});
+
+export default slice.reducer;

--- a/frontend/src/services/api/Api.ts
+++ b/frontend/src/services/api/Api.ts
@@ -2,7 +2,10 @@ import { Occupation } from '../../domain/occupation';
 import { State } from '../../domain/state';
 import { Transition } from '../../domain/transition';
 
-type GetTransitionRequest = { state?: State; occupation: { code: string } };
+export type GetTransitionRequest = {
+  state?: State;
+  occupation: { code: string };
+};
 
 export default interface Api {
   getOccupations: () => Promise<Occupation[]>;


### PR DESCRIPTION
Issues: [#108](https://github.com/codeforboston/jobhopper/issues/108) and [#114](https://github.com/codeforboston/jobhopper/issues/114)

@Dev1nxavier and I [completed our part](https://github.com/codeforboston/jobhopper/issues/108#issuecomment-708096621) of using Redux-toolkit to manage transitions state.