### PR TITLE
Connect BlsOes model to api/v1/jobs/soc-codes/ with pagination

### DIFF
--- a/data/scripts/sql_loader.py
+++ b/data/scripts/sql_loader.py
@@ -74,7 +74,8 @@ def load_bls_oes_to_sql(
             table_name,
             engine,
             if_exists="replace",
-            index=False,
+            index=True,
+            index_label="id",
             dtype={
                 "soc_decimal_code": String(),
                 "hourly_mean_wage": Numeric(),

--- a/jobhopper/settings.py
+++ b/jobhopper/settings.py
@@ -49,6 +49,11 @@ INSTALLED_APPS = [
     "jobs.apps.JobsConfig",
 ]
 
+REST_FRAMEWORK = {
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
+    'PAGE_SIZE': 100
+}
+
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",

--- a/jobs/api.py
+++ b/jobs/api.py
@@ -1,4 +1,4 @@
-from jobs.models import Socs, BlsOesFakes, StateAbbPairs, OccupationTransitions
+from jobs.models import Socs, BlsOes, StateAbbPairs, OccupationTransitions
 from rest_framework import viewsets, permissions, generics
 from .serializers import (
     SocSerializer,
@@ -15,7 +15,7 @@ class SocViewSet(viewsets.ModelViewSet):
 
 
 class BlsOesViewSet(viewsets.ModelViewSet):
-    queryset = BlsOesFakes.objects.all()
+    queryset = BlsOes.objects.all()
     permission_classes = [permissions.AllowAny]
     serializer_class = BlsOesSerializer
 

--- a/jobs/serializers.py
+++ b/jobs/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from jobs.models import Socs, BlsOesFakes, StateAbbPairs, OccupationTransitions
+from jobs.models import Socs, BlsOes, StateAbbPairs, OccupationTransitions
 
 # Lead Serializer
 class SocSerializer(serializers.ModelSerializer):
@@ -10,8 +10,14 @@ class SocSerializer(serializers.ModelSerializer):
 
 class BlsOesSerializer(serializers.ModelSerializer):
     class Meta:
-        model = BlsOesFakes
-        fields = "__all__"
+        model = BlsOes
+        fields = ("area_title",
+                  "soc_code",
+                  "soc_title",
+                  "hourly_mean_wage",
+                  "annual_mean_wage",
+                  "total_employment",
+                  "soc_decimal_code")
 
 
 class StateNamesSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
PR #140 populated the BlsOes Django model (jobs_blsoes Postgres table). This PR connects it to http://127.0.0.1:8000/api/v1/jobs/soc-codes/ and adds pagination so the page loads. It also adds the id column to the load process.

Running `python manage.py runserver` after re-running all migrations should allow data to be viewed from http://127.0.0.1:8000/api/v1/jobs/soc-codes/