### PR TITLE
Fixing bug with OES data loader

### DIFF
--- a/data/bls/oes_data_downloader.py
+++ b/data/bls/oes_data_downloader.py
@@ -99,7 +99,7 @@ class OESDataDownloader(object):
         dir = Path(__file__).parent / "downloads"
 
         download_filepath = str(dir) + "/{}/all_data_M_{}.xlsx".format(self.oes_zipname, self.year)
-        csv_path = download_filepath.split(".")[0] + ".csv"
+        csv_path = os.path.splitext(download_filepath)[0] + ".csv"
 
         if not os.path.exists(csv_path):
             zipfile = ZipFile(BytesIO(response.read()))


### PR DESCRIPTION
Fixes bug where the download fails if the download filepath includes `.` in the root path. 

Output for `python manage.py test`:
```
Creating test database for alias 'default'...
2020-10-28 23:28:29,413 Loading BLS wage and employment data to Postgres if a table_name is specified
2020-10-28 23:28:29,413 Connecting to Postgres DB via SQLAlchemy
2020-10-28 23:28:29,427 Finding OES data download path from https://www.bls.gov/oes/tables.htm
2020-10-28 23:28:29,649 Download path: https://www.bls.gov//oes/special.requests/oesm19all.zip
2020-10-28 23:28:29,650 Downloading OES data from https://www.bls.gov//oes/special.requests/oesm19all.zip if it has not been downloaded already
2020-10-28 23:28:29,848 OES data year 2019 was found in /Users/lilian.cheung/Documents/Code for Boston/jobhopper/data/bls/downloads/oesm19all/all_data_M_2019.csv. Loading it in.
2020-10-28 23:28:30,194 Successfully read OES data. Writing to the jobs_blsoes table
2020-10-28 23:29:04,734 Successfully loaded BLS data to Postgres!
Done with forward load
System check identified no issues (0 silenced).
.2020-10-28 23:29:04,940 Not Found: /jobs/api/leads
...
----------------------------------------------------------------------
Ran 4 tests in 0.046s

OK
Destroying test database for alias 'default'...
```