### PR TITLE
rate limiting example for all job endpoints

### DIFF
--- a/jobhopper/settings.py
+++ b/jobhopper/settings.py
@@ -53,7 +53,7 @@ REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
     'PAGE_SIZE': 100,
     'DEFAULT_THROTTLE_CLASSES': (
-        'rest_framework.throttling.AnonRateThrottle'
+        'rest_framework.throttling.AnonRateThrottle',
     ),
     'DEFAULT_THROTTLE_RATES': {
         'anon': '300/day'

--- a/jobhopper/settings.py
+++ b/jobhopper/settings.py
@@ -51,7 +51,13 @@ INSTALLED_APPS = [
 
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
-    'PAGE_SIZE': 100
+    'PAGE_SIZE': 100,
+    'DEFAULT_THROTTLE_CLASSES': (
+        'rest_framework.throttling.AnonRateThrottle'
+    ),
+    'DEFAULT_THROTTLE_RATES': {
+        'anon': '300/day'
+    }
 }
 
 MIDDLEWARE = [

--- a/jobs/api.py
+++ b/jobs/api.py
@@ -1,5 +1,6 @@
 from jobs.models import Socs, BlsOes, StateAbbPairs, OccupationTransitions
 from rest_framework import viewsets, permissions, generics
+from rest_framework.throttling import AnonRateThrottle
 from .serializers import (
     SocSerializer,
     BlsOesSerializer,
@@ -12,18 +13,21 @@ class SocViewSet(viewsets.ModelViewSet):
     queryset = Socs.objects.all()
     permission_classes = [permissions.AllowAny]
     serializer_class = SocSerializer
+    throttle_classes = [AnonRateThrottle]
 
 
 class BlsOesViewSet(viewsets.ModelViewSet):
     queryset = BlsOes.objects.all()
     permission_classes = [permissions.AllowAny]
     serializer_class = BlsOesSerializer
+    throttle_classes = [AnonRateThrottle]
 
 
 class StateViewSet(viewsets.ModelViewSet):
     queryset = StateAbbPairs.objects.all()
     permission_classes = [permissions.AllowAny]
     serializer_class = StateNamesSerializer
+    throttle_classes = [AnonRateThrottle]
 
 
 class OccupationTransitionsViewSetFive(viewsets.ModelViewSet):
@@ -31,3 +35,4 @@ class OccupationTransitionsViewSetFive(viewsets.ModelViewSet):
     queryset = OccupationTransitions.objects.all()[:500]
     permission_classes = [permissions.AllowAny]
     serializer_class = OccupationTransitionsSerializer
+    throttle_classes = [AnonRateThrottle]


### PR DESCRIPTION
Example of adding rate limiting to endpoints. Because users aren't authenticated, all users are treated as anonymous. 

This could run into issues if someone is a heavy user of the UI, they might get rate limited unintentionally. It may be worthwhile to split out endpoints that are at risk of being abused to be separate views so they can be rate limited and others won't be.

Mentions #163 