### PR TITLE
Iss 144

### DIFF
--- a/frontend/src/ui/ContactPage.stories.tsx
+++ b/frontend/src/ui/ContactPage.stories.tsx
@@ -1,0 +1,11 @@
+// also exported from '@storybook/react' if you can deal with breaking changes in 6.1
+import { Story, Meta } from '@storybook/react/types-6-0';
+import React from 'react';
+import ContactPage from './ContactPage';
+
+export default {
+  title: 'JobHopper/ContactPage',
+  component: ContactPage,
+} as Meta;
+
+export const Default = () => <ContactPage />;

--- a/frontend/src/ui/ContactPage.tsx
+++ b/frontend/src/ui/ContactPage.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Body, Title } from './Typography';
+
+const ContactPage = () => (
+  <div>
+    <Title>Contact Us</Title>
+    <Body>
+      For more information:
+      <br />
+      <br />
+      <a href="https://github.com/codeforboston/jobhopper/issues">
+        contact us by logging an issue
+      </a>
+      &nbsp; or
+      <br />
+      <br />
+      <a href="https://github.com/codeforboston/jobhopper/blob/develop/References/References.md">
+        Learn more about the data
+      </a>
+      <br />
+    </Body>
+  </div>
+);
+
+export default ContactPage;

--- a/frontend/src/ui/Percentage.stories.tsx
+++ b/frontend/src/ui/Percentage.stories.tsx
@@ -1,0 +1,40 @@
+// also exported from '@storybook/react' if you can deal with breaking changes in 6.1
+import { Meta, Story } from '@storybook/react/types-6-0';
+import React from 'react';
+import PercentageTypography, {
+  PercentageProps,
+  PrimaryPercentageTypography,
+  SecondaryPercentageTypography,
+} from './Percentage';
+
+export default {
+  title: 'JobHopper/PercentageTypography',
+  component: PercentageTypography,
+  decorators: [
+    Story => (
+      <div style={{ maxWidth: '300px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} as Meta;
+
+export const Percent_100: Story<PercentageProps> = args => (
+  <PercentageTypography {...args} />
+);
+Percent_100.args = { precision_digits: 5, label: '100%' };
+
+export const PrimaryWithPercent_43point2: Story<PercentageProps> = args => (
+  <PrimaryPercentageTypography {...args} />
+);
+PrimaryWithPercent_43point2.args = { precision_digits: 2, label: '%43.2' };
+
+export const SecondaryWithoutPercent_01point2: Story<PercentageProps> = args => (
+  <SecondaryPercentageTypography {...args} />
+);
+SecondaryWithoutPercent_01point2.args = { precision_digits: 2, label: '01.2' };
+
+export const PercentBadInput: Story<PercentageProps> = args => (
+  <PercentageTypography {...args} />
+);
+PercentBadInput.args = { precision_digits: 2, label: 'testing' };

--- a/frontend/src/ui/Percentage.tsx
+++ b/frontend/src/ui/Percentage.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import Typography from '@material-ui/core/Typography';
+import styled from 'styled-components';
+
+export interface PercentageProps {
+  label: string;
+  precision_digits: number;
+}
+
+function transformNumber(input: any, precision_digits: number) {
+  const stringInput = `${input}`.replace('%', '');
+  if (isNaN(Number.parseFloat(stringInput))) {
+    return NaN;
+  }
+
+  if (input.indexOf('%') > -1) {
+    return `${Number.parseFloat(stringInput).toFixed(precision_digits)} %`;
+  } else {
+    return `${(Number.parseFloat(stringInput) / 100).toFixed(
+      precision_digits
+    )} %`;
+  }
+}
+
+const UnstyledPercentageTypography = ({
+  label,
+  ...props
+}: PercentageProps): JSX.Element => (
+  <Typography variant={'body1'} {...props}>
+    {transformNumber(label, props.precision_digits)}
+  </Typography>
+);
+
+const PercentageTypography = styled(UnstyledPercentageTypography)`
+  && {
+    font-weight: bold;
+    color: black;
+    font-size: 10pt;
+    text-transform: none;
+  }
+`;
+
+export const PrimaryPercentageTypography = ({
+  label,
+  ...props
+}: PercentageProps): JSX.Element => (
+  <Typography color="primary" {...props}>
+    {transformNumber(label, props.precision_digits)}
+  </Typography>
+);
+
+export const SecondaryPercentageTypography = ({
+  label,
+  ...props
+}: PercentageProps): JSX.Element => (
+  <Typography color="secondary" {...props}>
+    {transformNumber(label, props.precision_digits)}
+  </Typography>
+);
+
+export default PercentageTypography;


### PR DESCRIPTION
closes #144 . Creates initial component for ui/design team to review. 
Stuck with standard Body component as part of typography -- so formatting doesn't match figma, but I think that is something that needs to be done holistically rather than fixing as a one-off on this component. 

Since the "maintenance" team is likely to change, I favored contact information being done via github.
Since we already had info about data sources in our wiki, pointed the link there. 
