### PR TITLE
Pass full state/occupation to getTransitions.

### DIFF
--- a/frontend/src/ducks/__tests__/store.ts
+++ b/frontend/src/ducks/__tests__/store.ts
@@ -80,7 +80,7 @@ describe('Transitions', () => {
 
     mockedApi.getTransitions.mockResolvedValue(transitions);
 
-    const payload: GetTransitionRequest = { socCode: '1' };
+    const payload: GetTransitionRequest = { sourceOccupation: occupations[0] };
 
     await store.dispatch(fetchTransitions(payload));
     expect(store.getState().transitions.transitions).toEqual(transitions);
@@ -95,7 +95,7 @@ describe('Transitions', () => {
     const errorMessage = 'test error fetching';
     mockedApi.getTransitions.mockRejectedValue(new Error(errorMessage));
 
-    const payload: GetTransitionRequest = { socCode: '1' };
+    const payload: GetTransitionRequest = { sourceOccupation: occupations[0] };
 
     await store.dispatch(fetchTransitions(payload));
     expect(store.getState().transitions.transitions).toHaveLength(0);
@@ -112,7 +112,7 @@ describe('Transitions', () => {
       message: errorMessage,
     });
 
-    const payload: GetTransitionRequest = { socCode: '1' };
+    const payload: GetTransitionRequest = { sourceOccupation: occupations[0] };
 
     await store.dispatch(fetchTransitions(payload));
     expect(store.getState().transitions.transitions).toHaveLength(0);

--- a/frontend/src/services/api/Api.ts
+++ b/frontend/src/services/api/Api.ts
@@ -3,8 +3,8 @@ import { State } from '../../domain/state';
 import { Transition } from '../../domain/transition';
 
 export type GetTransitionRequest = {
-  state?: string;
-  socCode: string;
+  state?: State;
+  sourceOccupation: Occupation;
 };
 
 export default interface Api {

--- a/frontend/src/services/api/__tests__/api.ts
+++ b/frontend/src/services/api/__tests__/api.ts
@@ -3,6 +3,7 @@ import FakeApi from '../FakeApi';
 import { Occupation } from '../../../domain/occupation';
 import { Transition } from '../../../domain/transition';
 import { State } from '../../../domain/state';
+import occupations from 'src/testing/data/occupations';
 
 describe('Fake API', () => {
   it('Fake can be constructed', () => {
@@ -35,7 +36,7 @@ describe('Fake API', () => {
   it('retrieves transitions', async () => {
     const api = new FakeApi();
     const transitions: Transition[] = await api.getTransitions({
-      socCode: '12345',
+      sourceOccupation: occupations[0],
     });
     transitions.forEach(
       ({ name, code, annualSalary, hourlyPay, transitionRate }) => {

--- a/frontend/src/services/api/__tests__/datahelper.ts
+++ b/frontend/src/services/api/__tests__/datahelper.ts
@@ -1,3 +1,4 @@
+import occupations from 'src/testing/data/occupations';
 import { Transition } from '../../../domain/transition';
 import DataHelper from '../DataHelper';
 import FakeApi from '../FakeApi';
@@ -6,7 +7,7 @@ describe('Testing Data Helper Functions', () => {
   it('transforms transitions', async () => {
     const api = new FakeApi();
     const transitions: Transition[] = await api.getTransitions({
-      socCode: '12345',
+      sourceOccupation: occupations[0],
     });
     expect(DataHelper.transformNumber(NaN, 1)).toBe(NaN);
     expect(DataHelper.transformNumber(-10, 2)).toBe(NaN);

--- a/frontend/src/ui/Results/ResultsContainer.tsx
+++ b/frontend/src/ui/Results/ResultsContainer.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { Occupation } from 'src/domain/occupation';
+import { State } from 'src/domain/state';
 import { selectOccupation, useOccupationsState } from 'src/ducks/occupations';
 import { selectState, useStateState } from 'src/ducks/states';
 import {
@@ -37,10 +38,10 @@ function useResultLoader() {
     { selectedOccupation } = useOccupationsState();
 
   const loadTransitions = useCallback(
-    (socCode: string, state?: string) =>
+    (sourceOccupation: Occupation, state?: State) =>
       dispatch(
         fetchTransitions({
-          socCode,
+          sourceOccupation,
           state,
         })
       ),
@@ -55,10 +56,7 @@ function useResultLoader() {
 
   useEffect(() => {
     if (canLoadTransitions(selectedOccupation)) {
-      const promise = loadTransitions(
-        selectedOccupation.code,
-        selectedState?.abbreviation
-      );
+      const promise = loadTransitions(selectedOccupation, selectedState);
       return () => {
         (promise as any).abort();
       };


### PR DESCRIPTION
The backend expects the full state name, so updating things to pass the full objects so that the implementation can pull the required info out.
