### PR TITLE
ISS-328: Tiered smart-search backend - adds fuzzy matching on top of O*NET results

### DIFF
--- a/api/jobs/views.py
+++ b/api/jobs/views.py
@@ -4,7 +4,8 @@ from .models import JobClass, BlsOesFakes
 from .serializers import BlsOesSerializer
 from django.template import loader
 
-# Create your views here.
+# Note: See api.py for views
+
 def index(request):
     jobs = JobClass.objects.all()
     template = loader.get_template("jobs/index.html")

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -31,6 +31,7 @@ python-dateutil==2.8.1
 python-decouple==3.4
 python-dotenv==0.14.0
 pytz==2020.1
+rapidfuzz==1.1.2
 regex==2020.7.14
 requests==2.24.0
 ruamel.yaml==0.16.12


### PR DESCRIPTION
Closes https://github.com/codeforboston/jobhopper/issues/328 

**Docker build notes**
* Docker needs to be rebuilt with the `--build` option (from the `stack` directory) due to additional requirements, i.e. `./start-dev --build`

**Changes**
* Adds fuzzy matching of search term to SOC titles in the transitions dataset, on top of O*NET results, so that outdated SOC codes with a near-exact match to the search term will still appear
![image](https://user-images.githubusercontent.com/35081231/111028108-7d0f9780-83c2-11eb-9031-a4dde367c8eb.png)

![image](https://user-images.githubusercontent.com/35081231/111028111-8862c300-83c2-11eb-999b-c5cf5f74647e.png)

**Tests**
* Built via virtualenv + docker
* Migration tests