### PR TITLE
Updated UI to incorporate Year information into footnote ISS#313

### DIFF
--- a/frontend/src/ui/TransitionTable.tsx
+++ b/frontend/src/ui/TransitionTable.tsx
@@ -116,7 +116,9 @@ const Explanation = ({ occupationName }: { occupationName: string }) => (
     they change occupation based on the observations in our dataset. The
     transition share is the percentage of these observed {occupationName} who
     have moved into each of the occupations listed. Only transition shares
-    greater than 0.2% are shown.
+    greater than 0.2% are shown. The information related to salary information
+    is sourced from bls and includes 2017 to 2019 with a preference for the most
+    recent data per soc code.
   </Body>
 );
 


### PR DESCRIPTION
This code adds new information to the footnote on the tabular visualization of transitions data.  This is static text "The information related to salary information is sourced from bls and includes 2017 to 2019 with a preference for the most recent data per soc code."