### PR TITLE
ISS-358 Sorted smart-search backend

### DIFF
--- a/api/jobs/api.py
+++ b/api/jobs/api.py
@@ -238,12 +238,13 @@ class SocListSmartViewSet(viewsets.ReadOnlyModelViewSet):
                                 for soc in fuzz_soc_codes
                                 if soc not in onet_soc_codes]
 
-        # Order response in by the highest fuzzy match score
+        # Order fuzzy-match occupations by the highest fuzzy match score
         available_fuzz_codes = sorted(available_fuzz_codes,
                                       key=lambda k: k.get("input_match_score"),
                                       reverse=True)
         available_fuzz_codes = [soc.get('soc_code') for soc in available_fuzz_codes]
 
+        # Return the fuzzy-matched occupations in best-worst score order and O*NET codes in their original order
         smart_soc_codes = available_fuzz_codes + available_onet_codes
         log.info(f'Combined SOC codes: {smart_soc_codes}')
 

--- a/api/jobs/api.py
+++ b/api/jobs/api.py
@@ -248,9 +248,8 @@ class SocListSmartViewSet(viewsets.ReadOnlyModelViewSet):
         smart_soc_codes = available_fuzz_codes + available_onet_codes
         log.info(f'Combined SOC codes: {smart_soc_codes}')
 
+        # Get actual metadata
         smart_socs = [available_soc_codes.get(soc) for soc in smart_soc_codes]
-
-        log.debug(f"Sorted smart_socs based on strength of match to input: {smart_socs}")
 
         return Response(smart_socs)
 

--- a/api/jobs/api.py
+++ b/api/jobs/api.py
@@ -122,11 +122,11 @@ class SocListSmartViewSet(viewsets.ReadOnlyModelViewSet):
 
     def _set_params(self, request):
         """
-       Set parameters based on the request. Custom parameters are identified by their openapi.Parameter name
+        Set parameters based on the request. Custom parameters are identified by their openapi.Parameter name
 
-       :param request: User-input parameters
-       :return: Relevant parameters from the request
-       """
+        :param request: User-input parameters
+        :return: Relevant parameters from the request
+        """
         self.keyword_search = request.query_params.get("keyword_search")
         self.onet_limit = request.query_params.get("onet_limit")
         self.obs_limit = request.query_params.get("min_weighted_obs")
@@ -138,26 +138,26 @@ class SocListSmartViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         """
-       Custom queryset used that is a combination of querysets from a couple models. Overwriting to prevent
-       schema generation warning.
-       """
+        Custom queryset used that is a combination of querysets from a couple models. Overwriting to prevent
+        schema generation warning.
+        """
         pass
 
     @staticmethod
     def search_onet_keyword(keyword: str,
                             limit: int = 20) -> Dict[str, Any]:
         """
-       Search for a keyword that will be matched to SOC codes via the O*Net API
+        Search for a keyword that will be matched to SOC codes via the O*Net API
 
-       :param keyword: Keyword that's requested (user search)
-       :param limit: Limit to number of results (should expose this as a parameter)
-       :return: JSON response, e.g. {'keyword': 'doctor', ...
+        :param keyword: Keyword that's requested (user search)
+        :param limit: Limit to number of results (should expose this as a parameter)
+        :return: JSON response, e.g. {'keyword': 'doctor', ...
                                      'career': [{'href': '',
                                                'code': '29-1216.00',
                                                'title': 'General Internal Medicine Physicians',
                                                'tags': {'bright_outlook': ...},
                                      ...]}
-       """
+        """
         headers = {"Accept": "application/json"}
         username = config("ONET_USERNAME")
         password = config("ONET_PASSWORD")


### PR DESCRIPTION
Minor change to ensure that the matches are ordered from best-worst score. Matches are from O*NET's API and other close results from our transitions data (SOCs not in O*NET but in our older transitions data) 

E.g. response when searching for 'physician'
```
[
  {
    "id": 169,
    "soc_code": "35-3031",
    "soc_title": "Waiters and Waitresses",
    "total_transition_obs": 661079.4,
    "input_match_score": 100
  },
  {
    "id": 137,
    "soc_code": "35-9011",
    "soc_title": "Dining Room and Cafeteria Attendants and Bartender Helpers",
    "total_transition_obs": 42645.41,
    "input_match_score": 66.66666666666666
  },
  {
    "id": 142,
    "soc_code": "37-2012",
    "soc_title": "Maids and Housekeeping Cleaners",
    "total_transition_obs": 78939.1,
    "input_match_score": 50
  },
  {
    "id": 235,
    "soc_code": "35-2021",
    "soc_title": "Food Preparation Workers",
    "total_transition_obs": 61772.94,
    "input_match_score": 50
  },
 
[...]

```