### PR TITLE
ISS 359 - Connect AsyncSelect to OccupationSelect and smart-soc-list endpoint

### DIFF
--- a/frontend/docker/Dockerfile
+++ b/frontend/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:14.15-alpine as debug
  
+RUN apk add --no-cache g++ make python
+
 # Project root
 WORKDIR /app
  

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14572,6 +14572,11 @@
         "@types/d3-selection": "^1"
       }
     },
+    "@types/debounce-promise": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/debounce-promise/-/debounce-promise-3.1.3.tgz",
+      "integrity": "sha512-mjcCf//DAUQ6YLQMhqYJAv/+a4BsE1GQFmy1el5K62wLJJmQwGi3TsnshhOFynPpuBF9Gh2Vvb+5ImPi47KaZw=="
+    },
     "@types/duplexify": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/@types/duplexify/-/duplexify-3.6.0.tgz",
@@ -16241,6 +16246,30 @@
         "num2fraction": "^1.2.2",
         "postcss": "^7.0.32",
         "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "awesome-debounce-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/awesome-debounce-promise/-/awesome-debounce-promise-2.1.0.tgz",
+      "integrity": "sha512-0Dv4j2wKk5BrNZh4jgV2HUdznaeVgEK/WTvcHhZWUElhmQ1RR+iURRoLEwICFyR0S/5VtxfcvY6gR+qSe95jNg==",
+      "requires": {
+        "@types/debounce-promise": "^3.1.1",
+        "awesome-imperative-promise": "^1.0.1",
+        "awesome-only-resolves-last-promise": "^1.0.3",
+        "debounce-promise": "^3.1.0"
+      }
+    },
+    "awesome-imperative-promise": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/awesome-imperative-promise/-/awesome-imperative-promise-1.0.1.tgz",
+      "integrity": "sha512-EmPr3FqbQGqlNh+WxMNcF9pO9uDQJnOC4/3rLBQNH9m4E9qI+8lbfHCmHpVAsmGqPJPKhCjJLHUQzQW/RBHRdQ=="
+    },
+    "awesome-only-resolves-last-promise": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/awesome-only-resolves-last-promise/-/awesome-only-resolves-last-promise-1.0.3.tgz",
+      "integrity": "sha512-7q4WPsYiD8Omvi/yHL314DkvsD/lM//Z2/KcU1vWk0xJotiV0GMJTgHTpWl3n90HJqpXKg7qX+VVNs5YbQyPRQ==",
+      "requires": {
+        "awesome-imperative-promise": "^1.0.1"
       }
     },
     "aws-sign2": {
@@ -21011,6 +21040,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.0.tgz",
       "integrity": "sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg=="
+    },
+    "debounce-promise": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/debounce-promise/-/debounce-promise-3.1.2.tgz",
+      "integrity": "sha512-rZHcgBkbYavBeD9ej6sP56XfG53d51CD4dnaw989YX/nZ/ZJfgRx/9ePKmTNiUiyQvh4mtrMoS3OAWW+yoYtpg=="
     },
     "debug": {
       "version": "4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "@types/react-router-dom": "^5.1.6",
     "@types/react-select": "^3.0.21",
     "@types/styled-components": "^5.1.3",
+    "awesome-debounce-promise": "^2.1.0",
     "axios": "^0.21.1",
     "canvg": "^3.0.7",
     "d3": "^6.2.0",

--- a/frontend/src/Main.test.tsx
+++ b/frontend/src/Main.test.tsx
@@ -77,7 +77,7 @@ describe('Main', () => {
 
     await selectEvent.select(
       getByLabelText('occupation-select'),
-      '11-1011 | Chief Executives'
+      '01-2345 | Doctor'
     );
 
     await waitFor(() => expect(getByText(/move to\?/i)).toBeInTheDocument());
@@ -98,7 +98,7 @@ describe('Main', () => {
 
     await selectEvent.select(
       getByLabelText('occupation-select'),
-      '11-1011 | Chief Executives'
+      '01-2345 | Doctor'
     );
     await selectEvent.select(getByLabelText('state-select'), 'California');
 

--- a/frontend/src/Main.test.tsx
+++ b/frontend/src/Main.test.tsx
@@ -26,9 +26,13 @@ afterEach(() => {
 describe('OccupationSelect', () => {
   it('Can use OccupationSelect', async () => {
     const mockOnChange = jest.fn();
+    const mockFetchOptions = async () => {
+      return [{ code: '01-2345', name: 'Doctor' }];
+    };
 
     const { container, getByLabelText } = render(
       <OccupationSelect
+        fetchOptions={mockFetchOptions}
         occupations={[{ code: '01-2345', name: 'Doctor' }]}
         onChange={mockOnChange}
       />
@@ -73,7 +77,7 @@ describe('Main', () => {
 
     await selectEvent.select(
       getByLabelText('occupation-select'),
-      '01-2345 | Doctor'
+      '11-1011 | Chief Executives'
     );
 
     await waitFor(() => expect(getByText(/move to\?/i)).toBeInTheDocument());
@@ -94,7 +98,7 @@ describe('Main', () => {
 
     await selectEvent.select(
       getByLabelText('occupation-select'),
-      '01-2345 | Doctor'
+      '11-1011 | Chief Executives'
     );
     await selectEvent.select(getByLabelText('state-select'), 'California');
 

--- a/frontend/src/ducks/__tests__/store.ts
+++ b/frontend/src/ducks/__tests__/store.ts
@@ -53,7 +53,7 @@ describe('Occupations', () => {
 
     mockedApi.getOccupations.mockResolvedValue(occupations);
 
-    await store.dispatch(fetchOccupations());
+    await store.dispatch(fetchOccupations('software'));
     expect(store.getState().occupations.occupations).toEqual(occupations);
     expect(store.getState().occupations.error).toBeUndefined();
     expect(store.getState().occupations.loading).toBeFalsy();
@@ -66,7 +66,7 @@ describe('Occupations', () => {
     const errorMessage = 'test error fetching';
     mockedApi.getOccupations.mockRejectedValue(new Error(errorMessage));
 
-    await store.dispatch(fetchOccupations());
+    await store.dispatch(fetchOccupations('software'));
     expect(store.getState().occupations.occupations).toHaveLength(0);
     expect(store.getState().occupations.error).toEqual(errorMessage);
     expect(store.getState().occupations.loading).toBeFalsy();

--- a/frontend/src/ducks/occupations.ts
+++ b/frontend/src/ducks/occupations.ts
@@ -1,12 +1,11 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
-import { sortBy } from 'lodash';
 import { shallowEqual, useSelector } from 'react-redux';
 import { Occupation } from '../domain/occupation';
 import api from '../services/api';
 
 export const fetchOccupations = createAsyncThunk(
   'occupations/fetchOccupations',
-  () => api.getOccupations('')
+  (searchKeyword: string) => api.getOccupations(searchKeyword)
 );
 
 type SliceState = {
@@ -33,7 +32,7 @@ const slice = createSlice({
     builder.addCase(
       fetchOccupations.fulfilled,
       (state, { payload: occupations }) => {
-        state.occupations = sortBy(occupations, ({ code }) => code);
+        state.occupations = occupations;
         state.loading = false;
         state.error = undefined;
       }

--- a/frontend/src/ducks/occupations.ts
+++ b/frontend/src/ducks/occupations.ts
@@ -6,7 +6,7 @@ import api from '../services/api';
 
 export const fetchOccupations = createAsyncThunk(
   'occupations/fetchOccupations',
-  () => api.getOccupations()
+  () => api.getOccupations('')
 );
 
 type SliceState = {

--- a/frontend/src/services/api/Api.ts
+++ b/frontend/src/services/api/Api.ts
@@ -8,7 +8,7 @@ export type GetTransitionRequest = {
 };
 
 export default interface Api {
-  getOccupations: () => Promise<Occupation[]>;
+  getOccupations: (request: string) => Promise<Occupation[]>;
 
   getStates: () => Promise<State[]>;
 

--- a/frontend/src/services/api/DjangoApiClient.ts
+++ b/frontend/src/services/api/DjangoApiClient.ts
@@ -17,9 +17,20 @@ export default class DjangoApiClient implements Api {
     });
   }
 
-  getOccupations(): Promise<Occupation[]> {
+  getOccupations(request: string): Promise<Occupation[]> {
+    /*
+     * Get occupations from the soc-smart-list Django API endpoint based on parameters defined in Api.ts
+     * Limit O*NET results to 30 (to be filtered against existing transitions data)
+     * Limit occupations returned to those with over 2000 (weighted) observations
+     */
     return this.axios
-      .get('/soc-list/')
+      .get('/soc-smart-list/', {
+        params: {
+          keyword_search: request,
+          onet_limit: 30,
+          min_weighted_obs: 2000,
+        },
+      })
       .then(response => response.data)
       .then((data: unknown) => array(data, occupation));
   }

--- a/frontend/src/services/api/DjangoApiClient.ts
+++ b/frontend/src/services/api/DjangoApiClient.ts
@@ -1,4 +1,5 @@
 import axiosModule, { AxiosInstance } from 'axios';
+import { sortBy } from 'lodash';
 import { Occupation } from 'src/domain/occupation';
 import { State } from 'src/domain/state';
 import { Transition } from 'src/domain/transition';
@@ -32,7 +33,13 @@ export default class DjangoApiClient implements Api {
         },
       })
       .then(response => response.data)
-      .then((data: unknown) => array(data, occupation));
+      .then((data: unknown) => array(data, occupation))
+      .then(occupations => {
+        if (request === '') {
+          return sortBy(occupations, ({ code }) => code);
+        }
+        return occupations;
+      });
   }
 
   getStates(): Promise<State[]> {

--- a/frontend/src/services/api/FakeApi.ts
+++ b/frontend/src/services/api/FakeApi.ts
@@ -15,7 +15,7 @@ export default class FakeApi implements Api {
     console.log('FakeApi.getStates');
     return resolveWithDelay(states);
   };
-  getOccupations = () => {
+  getOccupations = (request: string) => {
     console.log('FakeApi.getOccupations');
     return resolveWithDelay(occupations);
   };

--- a/frontend/src/services/api/__tests__/DjangoApiClient.ts
+++ b/frontend/src/services/api/__tests__/DjangoApiClient.ts
@@ -12,6 +12,8 @@ const selectedState: State = {
   name: 'Massachusetts',
 };
 
+var occupation = 'computer programmer';
+
 describe('DjangoApiClient', () => {
   it('Can be constructed', () => {
     expect(new DjangoApiClient()).toBeDefined();
@@ -24,7 +26,7 @@ describe('DjangoApiClient', () => {
     });
 
     it('Fetches Occupations (SOC list)', async () => {
-      const occupations = await client.getOccupations();
+      const occupations = await client.getOccupations(occupation);
       expect(occupations).not.toHaveLength(0);
       expect(occupations).toContainEqual(sourceOccupation);
     });

--- a/frontend/src/services/api/__tests__/FakeApi.ts
+++ b/frontend/src/services/api/__tests__/FakeApi.ts
@@ -16,7 +16,7 @@ describe('Fake API', () => {
 
   it('retrieves occupations', async () => {
     const api = new FakeApi();
-    const occupations: Occupation[] = await api.getOccupations();
+    const occupations: Occupation[] = await api.getOccupations('software');
     occupations.forEach(({ name, code }) => {
       expect(typeof name).toBe('string');
       expect(typeof code).toBe('string');

--- a/frontend/src/ui/Select/Select.stories.tsx
+++ b/frontend/src/ui/Select/Select.stories.tsx
@@ -1,5 +1,4 @@
-// also exported from '@storybook/react' if you can deal with breaking changes in 6.1
-import { Meta, Story } from '@storybook/react/types-6-0';
+import { Meta, Story } from '@storybook/react';
 import React from 'react';
 import occupations from '../../testing/data/occupations';
 import states from '../../testing/data/states';
@@ -30,7 +29,10 @@ const OccupationsTemplate: Story<OccupationSelectProps> = args => (
   <OccupationSelect {...args} />
 );
 OccupationsTemplate.args = {
-  occupations,
+  fetchOptions: input => {
+    console.log('fetchOptions', input);
+    return Promise.resolve(occupations);
+  },
   onSelectOccupation: o => console.log('occupation', o),
 };
 
@@ -46,7 +48,16 @@ ErrorOccupations.args = {
   error: 'Error loading occupations',
 };
 
-export const States: Story<StateSelectProps> = args => (
+const StatesTemplate: Story<StateSelectProps> = args => (
   <StateSelect {...args} />
 );
-States.args = { states, onSelectState: s => console.log('state', s) };
+StatesTemplate.args = { states, onSelectState: s => console.log('state', s) };
+
+export const NormalStates = StatesTemplate.bind({});
+NormalStates.args = { ...StatesTemplate.args };
+
+export const LoadingStates = StatesTemplate.bind({});
+LoadingStates.args = { ...StatesTemplate.args, loading: true };
+
+export const ErrorStates = StatesTemplate.bind({});
+ErrorStates.args = { ...StatesTemplate.args, error: 'Error loading states' };

--- a/frontend/src/ui/Select/Select.tsx
+++ b/frontend/src/ui/Select/Select.tsx
@@ -30,7 +30,7 @@ const fetchMatchOccupations = async (input: string) => {
       occupations.sort((job1, job2) => job1.code.localeCompare(job2.code));
     }
 
-    // Each occupation has the name and code attributes. These attributes are handled by OccupationSelect.
+    // Each occupation has the name and code attributes. These attributes are handled by OccupationSele
     return occupations.map(function (occupation) {
       return occupation;
     });

--- a/frontend/src/ui/Select/Select.tsx
+++ b/frontend/src/ui/Select/Select.tsx
@@ -1,6 +1,7 @@
 import { useTheme } from '@material-ui/core';
-import { type } from 'os';
 import React from 'react';
+
+import AwesomeDebouncePromise from 'awesome-debounce-promise';
 
 import ReactSelect, { Props } from 'react-select';
 import AsyncSelect from 'react-select/async';
@@ -14,28 +15,6 @@ export interface SelectProps<T> extends Props<T> {
   error?: string;
   disabled?: boolean;
 }
-
-const fetchMatchOccupations = async (input: string) => {
-  /*
-   * Fetch occupations matching the given input string via the soc-smart-list endpoint in the DjangoApiClient
-   */
-  console.log('Fetching occupations matching the input ' + input);
-  // TODO: Change the input.length to input complete
-  if (input.length >= 0) {
-    const client = new DjangoApiClient();
-    const occupations = await client.getOccupations(input);
-
-    // Sort by occupation SOC code if there is not input yet
-    if (input === '') {
-      occupations.sort((job1, job2) => job1.code.localeCompare(job2.code));
-    }
-
-    // Each occupation has the name and code attributes. These attributes are handled by OccupationSele
-    return occupations.map(function (occupation) {
-      return occupation;
-    });
-  }
-};
 
 export const Select = <T,>({
   options,
@@ -130,10 +109,11 @@ export interface OccupationSelectProps
 export const OccupationSelect = ({
   occupations,
   onSelectOccupation = () => {},
+  fetchOptions = (input: string) => {},
   ...rest
 }: OccupationSelectProps): JSX.Element => (
   <SelectAsync
-    loadOptions={fetchMatchOccupations}
+    loadOptions={fetchOptions}
     aria-label="occupation-select"
     options={occupations}
     placeholder={'Select occupation...'}

--- a/frontend/src/ui/Select/Select.tsx
+++ b/frontend/src/ui/Select/Select.tsx
@@ -1,5 +1,6 @@
 import { useTheme } from '@material-ui/core';
-import React from 'react';
+import AwesomeDebouncePromise from 'awesome-debounce-promise';
+import React, { useMemo } from 'react';
 import ReactSelect, { Props as SyncProps } from 'react-select';
 import AsyncSelect, { Props as AsyncProps } from 'react-select/async';
 import { Occupation } from '../../domain/occupation';
@@ -66,12 +67,19 @@ export const SelectAsync = <T,>({
   ...rest
 }: AsyncSelectProps<T>): JSX.Element => {
   const theme = useTheme();
+  // AwesomeDebouncePromise avoids an issue with lodash debounce where debounce
+  // returns the result of the previous query
+  const debouncedLoadOptions = useMemo(
+    () => AwesomeDebouncePromise(loadOptions, 500),
+    [loadOptions]
+  );
+
   return (
     <div>
       <AsyncSelect
         cacheOptions
         defaultOptions
-        loadOptions={loadOptions}
+        loadOptions={debouncedLoadOptions}
         placeholder={loading ? 'Loading...' : error || placeholder}
         getOptionLabel={getOptionLabel}
         getOptionValue={getOptionValue}
@@ -103,7 +111,6 @@ export interface OccupationSelectProps
 }
 
 export const OccupationSelect = ({
-  occupations,
   onSelectOccupation = () => {},
   fetchOptions: loadOptions = (input: string) => {},
   ...rest

--- a/frontend/src/ui/Select/Select.tsx
+++ b/frontend/src/ui/Select/Select.tsx
@@ -1,4 +1,5 @@
 import { useTheme } from '@material-ui/core';
+import { type } from 'os';
 import React from 'react';
 
 import ReactSelect, { Props } from 'react-select';
@@ -20,17 +21,27 @@ const fetchMatchOccupations = async (input: string) => {
    */
   console.log('Fetching occupations matching the input ' + input);
   // TODO: Change the input.length to input complete
-  if (input && input.length > 5) {
-    const occupationSearch = {
-      occupation: input,
-    };
+  if (input.length >= 0) {
     const client = new DjangoApiClient();
     const occupations = await client.getOccupations(input);
 
+    /*
     return occupations.map((occupation: { name: string; code: string }) => ({
       label: occupation.code + ' | ' + occupation.name,
       value: occupation.code,
     }));
+    
+    return occupations.map(function(occupation) {
+      console.log('Occupation returned: ' + occupation.name + '|' + occupation.code)
+      return ({
+        label: occupation.code + ' | ' + occupation.name,
+        value: occupation.code
+      })
+    });
+    */
+    return occupations.map(function (occupation) {
+      return occupation;
+    });
   }
 };
 

--- a/frontend/src/ui/Select/Select.tsx
+++ b/frontend/src/ui/Select/Select.tsx
@@ -25,20 +25,12 @@ const fetchMatchOccupations = async (input: string) => {
     const client = new DjangoApiClient();
     const occupations = await client.getOccupations(input);
 
-    /*
-    return occupations.map((occupation: { name: string; code: string }) => ({
-      label: occupation.code + ' | ' + occupation.name,
-      value: occupation.code,
-    }));
-    
-    return occupations.map(function(occupation) {
-      console.log('Occupation returned: ' + occupation.name + '|' + occupation.code)
-      return ({
-        label: occupation.code + ' | ' + occupation.name,
-        value: occupation.code
-      })
-    });
-    */
+    // Sort by occupation SOC code if there is not input yet
+    if (input === '') {
+      occupations.sort((job1, job2) => job1.code.localeCompare(job2.code));
+    }
+
+    // Each occupation has the name and code attributes. These attributes are handled by OccupationSelect.
     return occupations.map(function (occupation) {
       return occupation;
     });

--- a/frontend/src/ui/Select/SelectContainer.tsx
+++ b/frontend/src/ui/Select/SelectContainer.tsx
@@ -7,18 +7,46 @@ import {
 } from '../../ducks/occupations';
 import { fetchStates, useStateState, selectState } from '../../ducks/states';
 import { OccupationSelect, StateSelect } from './Select';
+import DjangoApiClient from '../../services/api/DjangoApiClient';
+import AwesomeDebouncePromise from 'awesome-debounce-promise';
+
+const fetchMatchOccupations = async (input: string) => {
+  /*
+   * Fetch occupations matching the given input string via the soc-smart-list endpoint in the DjangoApiClient
+   */
+  //console.log('Fetching occupations matching the input ' + input);
+  const client = new DjangoApiClient();
+  const occupations = await client.getOccupations(input);
+
+  // Sort by occupation SOC code if there is not input yet
+  if (input === '') {
+    //console.log('Sorting by job SOC code for default input')
+    occupations.sort((job1, job2) => job1.code.localeCompare(job2.code));
+  }
+
+  // Each occupation has the name and code attributes. These attributes are handled by OccupationSelect
+  return occupations.map(function (occupation) {
+    return occupation;
+  });
+};
+
+// AwesomeDebouncePromise avoids an issue with lodash debounce where debounce returns the result of the previous query
+const debounceMatchOccupations = AwesomeDebouncePromise(
+  fetchMatchOccupations,
+  500
+);
 
 export const OccupationSelectContainer: React.FC = () => {
+  /*
+   * Construct select container to render OccupationSelect, which displays available transition source occupations
+   */
   const dispatch = useDispatch();
 
   const { occupations, loading, error } = useOccupationsState();
 
-  useEffect(() => {
-    dispatch(fetchOccupations());
-  }, [dispatch]);
-
   return (
     <OccupationSelect
+      fetchOptions={debounceMatchOccupations}
       onSelectOccupation={occupation => dispatch(selectOccupation(occupation))}
       loading={loading}
       error={error}

--- a/frontend/src/ui/Select/SelectContainer.tsx
+++ b/frontend/src/ui/Select/SelectContainer.tsx
@@ -42,13 +42,12 @@ export const OccupationSelectContainer: React.FC = () => {
    */
   const dispatch = useDispatch();
 
-  const { occupations, loading, error } = useOccupationsState();
+  const { occupations, error } = useOccupationsState();
 
   return (
     <OccupationSelect
       fetchOptions={debounceMatchOccupations}
       onSelectOccupation={occupation => dispatch(selectOccupation(occupation))}
-      loading={loading}
       error={error}
       occupations={occupations}
     />

--- a/frontend/src/ui/TransitionPage/TransitionPage.stories.tsx
+++ b/frontend/src/ui/TransitionPage/TransitionPage.stories.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-// also exported from '@storybook/react' if you can deal with breaking changes in 6.1
-import { Story, Meta } from '@storybook/react/types-6-0';
+import { Story, Meta } from '@storybook/react';
 
 import TransitionPage, { ContainerContext } from './TransitionPage';
 import * as Select from '../Select/Select.stories';
@@ -15,7 +14,7 @@ export default {
 const Template: Story<{
   resultsArgs: typeof Results.Display.args;
   occupationSelectArgs: typeof Select.NormalOccupations.args;
-  stateSelectArgs: typeof Select.States.args;
+  stateSelectArgs: typeof Select.NormalStates.args;
   resultsStory: typeof Results.Display;
 }> = ({ resultsArgs, occupationSelectArgs, stateSelectArgs, resultsStory }) => (
   <ContainerContext.Provider
@@ -24,7 +23,7 @@ const Template: Story<{
         Select.NormalOccupations,
         occupationSelectArgs
       ),
-      StateSelectContainer: bindArgs(Select.States, stateSelectArgs),
+      StateSelectContainer: bindArgs(Select.NormalStates, stateSelectArgs),
       ResultsContainer: bindArgs(resultsStory, resultsArgs),
     }}
   >
@@ -37,5 +36,5 @@ Default.args = {
   resultsStory: Results.Display,
   resultsArgs: Results.Display.args,
   occupationSelectArgs: Select.NormalOccupations.args,
-  stateSelectArgs: Select.States.args,
+  stateSelectArgs: Select.NormalStates.args,
 };

--- a/frontend/src/ui/TransitionTable.tsx
+++ b/frontend/src/ui/TransitionTable.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
-import MaterialTable from 'material-table';
-import { Transition } from '../domain/transition';
 import { Typography, useTheme } from '@material-ui/core';
-import OnetLink from './OnetLink';
-import DataHelper from 'src/services/api/DataHelper';
-// leaving these two lines from develop branch. used in TransitionTableProps
+import MaterialTable from 'material-table';
+import React, { useCallback } from 'react';
 import { Occupation } from 'src/domain/occupation';
+import DataHelper from 'src/services/api/DataHelper';
+import { Transition } from '../domain/transition';
+import OnetLink from './OnetLink';
 import { Body } from './Typography';
 
 export interface TransitionTableProps {
@@ -23,16 +22,17 @@ const TransitionTable = ({
 
   const title = `Which occupations do ${selectedOccupation.name}  (${selectedOccupation.code}) move to?`;
 
+  const scrollToOnMount = useCallback((ref: any) => {
+    console.log('ref', ref);
+    (ref?.tableContainerDiv?.current as HTMLDivElement)?.scrollIntoView?.({
+      behavior: 'smooth',
+    });
+  }, []);
+
   return (
     <>
       <MaterialTable
-        tableRef={(ref: any) =>
-          (ref?.tableContainerDiv?.current as HTMLDivElement)?.scrollIntoView?.(
-            {
-              behavior: 'smooth',
-            }
-          )
-        }
+        tableRef={scrollToOnMount}
         style={centerWide}
         columns={[
           {

--- a/frontend/src/ui/TransitionTable.tsx
+++ b/frontend/src/ui/TransitionTable.tsx
@@ -22,12 +22,13 @@ const TransitionTable = ({
 
   const title = `Which occupations do ${selectedOccupation.name}  (${selectedOccupation.code}) move to?`;
 
-  const scrollToOnMount = useCallback((ref: any) => {
-    console.log('ref', ref);
-    (ref?.tableContainerDiv?.current as HTMLDivElement)?.scrollIntoView?.({
-      behavior: 'smooth',
-    });
-  }, []);
+  const scrollToOnMount = useCallback(
+    (ref: any) =>
+      (ref?.tableContainerDiv?.current as HTMLDivElement)?.scrollIntoView?.({
+        behavior: 'smooth',
+      }),
+    []
+  );
 
   return (
     <>


### PR DESCRIPTION
https://github.com/codeforboston/jobhopper/issues/359

**Changes**
* Adds `awesome-debounce-promise` package
* Adds debouncing to user input
* Takes user's input for occupation select search and routes it to the `smart-soc-list` endpoint, returning an occupation that's routed to the `transitions-extended` endpoint (like before)

**Example**
* Current deployment:
![image](https://user-images.githubusercontent.com/35081231/114315012-149ffd00-9acb-11eb-8071-eff665a1cad3.png)
* After changes:
![image](https://user-images.githubusercontent.com/35081231/114315038-2681a000-9acb-11eb-9357-02e43bebfec7.png)

