### PR TITLE
Fix error handling on front and backends

### DIFF
--- a/api/jobs/api.py
+++ b/api/jobs/api.py
@@ -214,6 +214,7 @@ class SocListSmartViewSet(viewsets.ReadOnlyModelViewSet):
                 log.info(f"Smart search SOC codes: {onet_soc_codes}")
             except Exception as e:
                 log.info(f"Unable to find search results from O*NET for keyword {self.keyword_search} | {e}")
+                onet_soc_codes = []
 
         # Default response when there is not yet a keyword typed
         if not self.keyword_search:

--- a/frontend/src/ui/Select/Select.tsx
+++ b/frontend/src/ui/Select/Select.tsx
@@ -97,7 +97,7 @@ export const SelectAsync = <T,>({
           }),
         }}
         isLoading={loading}
-        isDisabled={disabled || loading || !!error}
+        isDisabled={disabled || loading}
         {...rest}
       />
     </div>


### PR DESCRIPTION
Searching for a keyword without results causes an error in api.py. On
the frontend, an error disables the dropdown.

This change sets results to an empty array on error and doesn't disable
the dropdown so users can search again.
